### PR TITLE
Change deprecated items

### DIFF
--- a/custom_components/meross_cloud/climate.py
+++ b/custom_components/meross_cloud/climate.py
@@ -3,7 +3,7 @@ from typing import List, Optional
 
 from homeassistant.components.climate import (SUPPORT_PRESET_MODE,
                                               SUPPORT_TARGET_TEMPERATURE,
-                                              ClimateDevice)
+                                              ClimateEntity)
 from homeassistant.components.climate.const import (CURRENT_HVAC_HEAT,
                                                     CURRENT_HVAC_IDLE,
                                                     CURRENT_HVAC_OFF,
@@ -32,7 +32,7 @@ def none_callback(err, resp):
     pass
 
 
-class ValveEntityWrapper(ClimateDevice, MerossEntityWrapper):
+class ValveEntityWrapper(ClimateEntity, MerossEntityWrapper):
     """Wrapper class to adapt the Meross thermostat into the Homeassistant platform"""
 
     def __init__(self, device: ValveSubDevice):

--- a/custom_components/meross_cloud/cover.py
+++ b/custom_components/meross_cloud/cover.py
@@ -1,7 +1,7 @@
 import logging
 
 from homeassistant.components.cover import (
-    DEVICE_CLASS_GARAGE, SUPPORT_CLOSE, SUPPORT_OPEN, CoverDevice)
+    DEVICE_CLASS_GARAGE, SUPPORT_CLOSE, SUPPORT_OPEN, CoverEntity)
 from meross_iot.cloud.client_status import ClientStatus
 from meross_iot.cloud.devices.door_openers import GenericGarageDoorOpener
 from meross_iot.cloud.exceptions.CommandTimeoutException import CommandTimeoutException
@@ -15,7 +15,7 @@ ATTR_DOOR_STATE = 'door_state'
 PARALLEL_UPDATES = 1
 
 
-class OpenGarageCover(CoverDevice, MerossEntityWrapper):
+class OpenGarageCover(CoverEntity, MerossEntityWrapper):
     """Representation of a OpenGarage cover."""
 
     def __init__(self, device: GenericGarageDoorOpener):

--- a/custom_components/meross_cloud/light.py
+++ b/custom_components/meross_cloud/light.py
@@ -4,7 +4,7 @@ import homeassistant.util.color as color_util
 from homeassistant.components.light import (ATTR_BRIGHTNESS, ATTR_COLOR_TEMP,
                                             ATTR_HS_COLOR, SUPPORT_BRIGHTNESS,
                                             SUPPORT_COLOR, SUPPORT_COLOR_TEMP,
-                                            Light)
+                                            LightEntity)
 from meross_iot.cloud.client_status import ClientStatus
 from meross_iot.cloud.devices.light_bulbs import GenericBulb
 from meross_iot.cloud.exceptions.CommandTimeoutException import CommandTimeoutException
@@ -30,7 +30,7 @@ def expand_status(status):
     return out
 
 
-class LightEntityWrapper(Light):
+class LightEntityWrapper(LightEntity):
     """Wrapper class to adapt the Meross switches into the Homeassistant platform"""
 
     def __init__(self, device: GenericBulb, channel: int):

--- a/custom_components/meross_cloud/switch.py
+++ b/custom_components/meross_cloud/switch.py
@@ -1,6 +1,6 @@
 import logging
 
-from homeassistant.components.switch import SwitchDevice
+from homeassistant.components.switch import SwitchEntity
 from meross_iot.cloud.client_status import ClientStatus
 from meross_iot.cloud.devices.power_plugs import GenericPlug
 from meross_iot.cloud.exceptions.CommandTimeoutException import CommandTimeoutException
@@ -13,7 +13,7 @@ _LOGGER = logging.getLogger(__name__)
 PARALLEL_UPDATES = 1
 
 
-class SwitchEntityWrapper(SwitchDevice, MerossEntityWrapper):
+class SwitchEntityWrapper(SwitchEntity, MerossEntityWrapper):
     """Wrapper class to adapt the Meross switches into the Homeassistant platform"""
 
     def __init__(self, device: GenericPlug, channel: int):


### PR DESCRIPTION
HA appears to use Entity instead of Device so I went and changed them.

Should resolve these errors in the HA log:

`ClimateDevice is deprecated, modify ValveEntityWrapper to extend ClimateEntity`
`SwitchDevice is deprecated, modify SwitchEntityWrapper to extend SwitchEntity`
`Light is deprecated, modify LightEntityWrapper to extend LightEntity`
`CoverDevice is deprecated, modify OpenGarageCover to extend CoverEntity`