### PR TITLE
adding energy sensor for plugs

### DIFF
--- a/custom_components/meross_cloud/sensor.py
+++ b/custom_components/meross_cloud/sensor.py
@@ -286,7 +286,7 @@ class EnergySensorWrapper(GenericSensorWrapper):
 
     @property
     def should_poll(self) -> bool:
-        return False
+        return True
 
 # ----------------------------------------------
 # PLATFORM METHODS


### PR DESCRIPTION
Since homeassistant deprecated the energy and power in switch entity, moving energy as sensor.