### PR TITLE
Change log level of Skip MQTT cert validation option

### DIFF
--- a/custom_components/meross_cloud/__init__.py
+++ b/custom_components/meross_cloud/__init__.py
@@ -364,7 +364,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry):
     _LOGGER.info("Loaded %s: %s", CONF_STORED_CREDS, "******")
 
     mqtt_skip_cert_validation = config_entry.data.get(CONF_MQTT_SKIP_CERT_VALIDATION, True)
-    _LOGGER.warning("Skip MQTT cert validation option set to: %s", mqtt_skip_cert_validation)
+    _LOGGER.info("Skip MQTT cert validation option set to: %s", mqtt_skip_cert_validation)
 
     mqtt_override_address = config_entry.data.get(CONF_OVERRIDE_MQTT_ENDPOINT)
     _LOGGER.info("Override MQTT address set to: %s", "no" if mqtt_override_address is None else "yes -> %s" % mqtt_override_address)


### PR DESCRIPTION
Changed from warning to info to prevent unnecessary warnings in the Logs page