### PR TITLE
Update meross_iot dependency to 0.4.9.0

### DIFF
--- a/custom_components/meross_cloud/manifest.json
+++ b/custom_components/meross_cloud/manifest.json
@@ -5,7 +5,7 @@
   "issue_tracker": "https://github.com/albertogeniola/meross-homeassistant",
   "dependencies": ["persistent_notification"],
   "codeowners": ["@albertogeniola"],
-  "requirements": ["meross_iot==0.4.8.0"],
+  "requirements": ["meross_iot==0.4.9.0"],
   "config_flow": true,
   "quality_scale": "platinum",
   "iot_class": "cloud_push",


### PR DESCRIPTION
With the [latest released update](https://github.com/albertogeniola/meross-homeassistant/releases/tag/v1.3.5) there is an error with the `meross_iot` dependency, updating it the integration manages to load successfully @albertogeniola 