### PR TITLE
fix:  use hass.config_entries.async_forward_entry_setups() as hass.co…

### DIFF
--- a/custom_components/meross_cloud/__init__.py
+++ b/custom_components/meross_cloud/__init__.py
@@ -422,10 +422,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry):
         hass.data[DOMAIN][DEVICE_LIST_COORDINATOR] = meross_coordinator
 
         # Once the manager is ok and the first discovery was issued, we can proceed with platforms setup.
-        for platform in MEROSS_PLATFORMS:
-            hass.async_create_task(
-                hass.config_entries.async_forward_entry_setup(config_entry, platform)
-            )
+        await hass.config_entries.async_forward_entry_setups(config_entry, MEROSS_PLATFORMS)
 
         def _http_api_polled(*args, **kwargs):
             # Whenever a new HTTP device is seen, we issue a discovery


### PR DESCRIPTION
…nfig_entries.async_forward_entry_setup() has been removed

fixes https://github.com/albertogeniola/meross-homeassistant/issues/554

Source - https://developers.home-assistant.io/blog/2024/06/12/async_forward_entry_setups/
> Calling hass.config_entries.async_forward_entry_setup is deprecated and will be removed in Home Assistant 2025.6. Instead, await hass.config_entries.async_forward_entry_setups as it can load multiple platforms at once and is more efficient since it does not require a separate import executor job for each platform.