### PR TITLE
fix(light): fix color-temp out-of-range errors and migrate to ATTR_COLOR_TEMP_KELVIN

### DIFF
--- a/custom_components/meross_cloud/light.py
+++ b/custom_components/meross_cloud/light.py
@@ -11,7 +11,7 @@ from meross_iot.model.enums import DiffuserLightMode
 import homeassistant.util.color as color_util
 from homeassistant.components.light import LightEntity
 from homeassistant.components.light import ColorMode, \
-    ATTR_HS_COLOR, ATTR_COLOR_TEMP, ATTR_BRIGHTNESS, ATTR_RGB_COLOR
+    ATTR_HS_COLOR, ATTR_COLOR_TEMP_KELVIN, ATTR_BRIGHTNESS, ATTR_RGB_COLOR
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from . import MerossDevice
 from .common import (DOMAIN, MANAGER, HA_LIGHT, DEVICE_LIST_COORDINATOR)
@@ -39,6 +39,8 @@ class DiffuserLightEntityWrapper(MerossDevice, LightEntity):
     # For now, we assume OilDiffuserLight supports all the following features.
     # From Meross API it is in fact impossible to determine which exact features are supported by the device.
     _attr_supported_color_modes = {ColorMode.WHITE, ColorMode.RGB, ColorMode.COLOR_TEMP}
+    _attr_min_color_temp_kelvin: int = 2700  # warmest white (≈370 mired)
+    _attr_max_color_temp_kelvin: int = 6500  # coolest white (≈154 mired)
 
     def __init__(self,
                  channel: int,
@@ -63,11 +65,14 @@ class DiffuserLightEntityWrapper(MerossDevice, LightEntity):
             rgb = color_util.color_hsv_to_RGB(h, s, 100)
             _LOGGER.debug("color change: rgb=%r -- h=%r s=%r" % (rgb, h, s))
             await self._device.async_set_light_mode(channel=self._channel_id, mode=DiffuserLightMode.FIXED_RGB, rgb=rgb, onoff=True, skip_rate_limits=True)
-        elif ATTR_COLOR_TEMP in kwargs:
-            mired = kwargs[ATTR_COLOR_TEMP]
-            norm_value = (mired - self.min_mireds) / (self.max_mireds - self.min_mireds)
-            temperature = 100 - (norm_value * 100)
-            _LOGGER.debug("temperature change: mired=%r meross=%r" % (mired, temperature))
+        elif ATTR_COLOR_TEMP_KELVIN in kwargs:
+            kelvin = kwargs[ATTR_COLOR_TEMP_KELVIN]
+            norm_value = (kelvin - self.min_color_temp_kelvin) / (self.max_color_temp_kelvin - self.min_color_temp_kelvin)
+            temperature = round(norm_value * 100)
+            # Meross API accepts temperature in 1-100; clamp to avoid "Out of range" errors
+            # from edge-case kelvin values or floating-point drift.
+            temperature = max(1, min(100, temperature))
+            _LOGGER.debug("temperature change: kelvin=%r meross=%r" % (kelvin, temperature))
             await self._device.async_set_light_mode(channel=self._channel_id, mode=DiffuserLightMode.FIXED_LUMINANCE, onoff=True, rgb=65293, brightness=temperature, skip_rate_limits=True)
 
         # Brightness must always be set, so take previous luminance if not explicitly set now.
@@ -99,6 +104,8 @@ class DiffuserLightEntityWrapper(MerossDevice, LightEntity):
 class LightEntityWrapper(MerossDevice, LightEntity):
     """Wrapper class to adapt the Meross bulbs into the Homeassistant platform"""
     _device: MerossLightDevice
+    _attr_min_color_temp_kelvin: int = 2700  # warmest white (≈370 mired)
+    _attr_max_color_temp_kelvin: int = 6500  # coolest white (≈154 mired)
 
     def __init__(self,
                  channel: int,
@@ -126,11 +133,14 @@ class LightEntityWrapper(MerossDevice, LightEntity):
             rgb = color_util.color_hsv_to_RGB(h, s, 100)
             _LOGGER.debug("color change: rgb=%r -- h=%r s=%r" % (rgb, h, s))
             await self._device.async_set_light_color(channel=self._channel_id, rgb=rgb, onoff=True, skip_rate_limits=True)
-        elif ATTR_COLOR_TEMP in kwargs:
-            mired = kwargs[ATTR_COLOR_TEMP]
-            norm_value = (mired - self.min_mireds) / (self.max_mireds - self.min_mireds)
-            temperature = 100 - (norm_value * 100)
-            _LOGGER.debug("temperature change: mired=%r meross=%r" % (mired, temperature))
+        elif ATTR_COLOR_TEMP_KELVIN in kwargs:
+            kelvin = kwargs[ATTR_COLOR_TEMP_KELVIN]
+            norm_value = (kelvin - self.min_color_temp_kelvin) / (self.max_color_temp_kelvin - self.min_color_temp_kelvin)
+            temperature = round(norm_value * 100)
+            # Meross API accepts temperature in 1-100; clamp to avoid "Out of range" errors
+            # from edge-case kelvin values or floating-point drift.
+            temperature = max(1, min(100, temperature))
+            _LOGGER.debug("temperature change: kelvin=%r meross=%r" % (kelvin, temperature))
             await self._device.async_set_light_color(channel=self._channel_id, temperature=temperature, skip_rate_limits=True)
 
         # Brightness must always be set, so take previous luminance if not explicitly set now.
@@ -188,11 +198,11 @@ class LightEntityWrapper(MerossDevice, LightEntity):
             return None  # Return None if RGB value is not available
 
     @property
-    def color_temp(self):
+    def color_temp_kelvin(self):
         if self._device.get_supports_temperature(channel=self._channel_id):
             value = self._device.get_color_temperature()
-            norm_value = (100 - value) / 100.0
-            return self.min_mireds + (norm_value * (self.max_mireds - self.min_mireds))
+            norm_value = value / 100.0
+            return round(self.min_color_temp_kelvin + (norm_value * (self.max_color_temp_kelvin - self.min_color_temp_kelvin)))
         return None
 
 


### PR DESCRIPTION
## Problem

Meross bulbs that support white/colour-temperature mode (e.g. MSL120D) return error code 5000 when Home Assistant sends a `temperature` payload outside the accepted range of 1–100:

```
Returned error: {'error': {'code': 5000, 'detail': 'Out of range.
  rgb value range: 0X0~0XFFFFFF, temperature range: 1~100, luminance range: 1~100'}}
```

The root causes were:

1. **No clamping** – the mired-to-Meross conversion (`100 - norm_value * 100`) produced negative values or values > 100 when the input fell outside the assumed min/max mired range.
2. **Deprecated API** – the code used `ATTR_COLOR_TEMP` (mired-based), which HA has deprecated and will remove in **HA Core 2026.1**, producing warnings in the log.
3. **No explicit kelvin range** – neither entity class declared `_attr_min_color_temp_kelvin` / `_attr_max_color_temp_kelvin`, so the HA UI slider used HA's broad defaults instead of the Meross-supported range.

## Changes

- **Migrate to `ATTR_COLOR_TEMP_KELVIN`** in both `LightEntityWrapper` and `DiffuserLightEntityWrapper`, eliminating the HA 2026.1 deprecation warning.
- **Simplify conversion** – work directly in Kelvin (no mired inversion), mapping the device's 2700–6500 K range linearly to Meross's 1–100 scale.
- **Clamp output** with `max(1, min(100, value))` as a safety net for edge-case inputs or floating-point drift.
- **Declare kelvin range** (`_attr_min_color_temp_kelvin = 2700`, `_attr_max_color_temp_kelvin = 6500`) on both entity classes so the HA slider stays within supported bounds.
- **Replace `color_temp` with `color_temp_kelvin`** on `LightEntityWrapper` to match the new API.

## Compatibility

No existing configuration is broken:
- RGB and HS colour paths are **untouched**.
- Brightness/luminance path is **untouched**.
- The fix applies only to the colour-temperature conversion branch.
- The 2700–6500 K range covers all known Meross white-spectrum bulbs.

## Tested devices

| Model | Hardware | Firmware | White mode | Colour-temp slider | RGB mode |
|-------|----------|----------|------------|--------------------|----------|
| MSL120D | 2.0.0 | 2.1.5 | ✅ | ✅ (no more Out of range errors) | ✅ |

> If you test this on additional devices, please comment below and I will update the table.