### PR TITLE
Retry setup on transient network errors instead of failing permanently

### DIFF
--- a/custom_components/meross_cloud/__init__.py
+++ b/custom_components/meross_cloud/__init__.py
@@ -4,6 +4,7 @@ import logging
 from datetime import datetime, timedelta
 from typing import List, Tuple, Dict, Optional, Collection
 
+import aiohttp
 import homeassistant.helpers.config_validation as cv
 import voluptuous as vol
 from homeassistant import config_entries
@@ -148,6 +149,9 @@ class MerossCoordinator(DataUpdateCoordinator):
         except (BadLoginException, TokenExpiredException, UnauthorizedException) as err:
             raise ConfigEntryAuthFailed from err
         except HttpApiError as err:
+            raise ConfigEntryNotReady(f"Error communicating with API: {err}") from err
+        except (aiohttp.ClientError, asyncio.TimeoutError) as err:
+            # Transient transport failure: retry setup rather than give up
             raise ConfigEntryNotReady(f"Error communicating with API: {err}") from err
 
         # If a new token was issued, store it into the current entry
@@ -468,6 +472,13 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry):
             )
             log_exception(msg, logger=_LOGGER)
             raise ConfigEntryNotReady()
+
+    except (aiohttp.ClientError, asyncio.TimeoutError) as ex:
+        # Cloud unreachable at setup time (DNS not up yet at boot, WAN down):
+        # retry with backoff instead of failing the entry permanently
+        msg = "Could not reach the Meross cloud while setting up the integration."
+        log_exception(msg, logger=_LOGGER)
+        raise ConfigEntryNotReady(msg) from ex
 
 
 async def update_listener(hass, entry):

--- a/custom_components/meross_cloud/__init__.py
+++ b/custom_components/meross_cloud/__init__.py
@@ -21,6 +21,7 @@ from meross_iot.model.enums import OnlineStatus, Namespace
 from meross_iot.model.exception import CommandTimeoutError
 from meross_iot.model.http.device import HttpDeviceInfo
 from meross_iot.model.http.exception import (
+    AuthenticatedPostException,
     TokenExpiredException,
     TooManyTokensException,
     UnauthorizedException,
@@ -53,6 +54,25 @@ from .common import (
 from .version import MEROSS_IOT_VERSION
 
 _LOGGER = logging.getLogger(__name__)
+
+# Transport-level failures worth retrying instead of failing the entry until the next restart:
+# - OSError: ConnectionRefusedError/ConnectionResetError, socket.gaierror, EINVAL from an unscoped
+#   IPv6 link-local address (ha-meross-local-broker#63), paho's synchronous client.connect() to the
+#   MQTT broker, and TimeoutError raised by asyncio.timeout() (TimeoutError subclasses OSError).
+# - aiohttp.ClientError: ClientConnectorError (also an OSError), ClientConnectorDNSError,
+#   ServerDisconnectedError, ClientPayloadError/ContentTypeError while a proxy is (re)starting.
+# - AuthenticatedPostException: meross_iot raises this *base* class for any non-200 status (e.g. the
+#   502/503/504 the local add-on's nginx returns while Flask is down). HttpApiError is its subclass
+#   and must keep being matched by the more specific except clauses that precede this tuple.
+# Never widen this to Exception: ConfigEntryNotReady/ConfigEntryAuthFailed raised inside the try
+# blocks must propagate, and asyncio.CancelledError (a BaseException) must never be swallowed.
+RETRYABLE_TRANSPORT_ERRORS = (AuthenticatedPostException, aiohttp.ClientError, OSError, TimeoutError)
+
+# Upper bound for the first devList call during setup. aiohttp defaults are sock_connect=30s /
+# total=300s and the local add-on's nginx uses proxy_read_timeout 1200s, so a hung backend could
+# otherwise stall the entry (and HA startup) for minutes. 30s = aiohttp's own connect budget and 3x
+# the 10s used by the periodic poll; HA's first retry follows a few seconds later anyway.
+SETUP_HTTP_TIMEOUT_SECONDS = 30
 
 CONFIG_SCHEMA = vol.Schema(
     {
@@ -133,6 +153,13 @@ class MerossCoordinator(DataUpdateCoordinator):
             raise ConfigEntryAuthFailed from err
         except HttpApiError as err:
             raise UpdateFailed(f"Error communicating with API: {err}")
+        except RETRYABLE_TRANSPORT_ERRORS as err:
+            # Transient transport failure: entities go unavailable, polling continues. Without this,
+            # a 502 or a bare OSError is logged by the coordinator as an "Unexpected error" traceback.
+            raise UpdateFailed(
+                f"Cannot reach the Meross HTTP API at {self._http_api_endpoint}: "
+                f"{type(err).__name__}: {err}"
+            ) from err
 
     async def initial_setup(self):
         if self._setup_done:
@@ -141,18 +168,30 @@ class MerossCoordinator(DataUpdateCoordinator):
         # Test the stored credentials if any. In case the credentials are invalid
         # try to retrieve a new token
         try:
-            self._client, http_devices, creds_renewed = await get_or_test_creds(
-                http_api_url=self._http_api_endpoint,
-                creds=self._cached_creds,
-                ua_header=self._ua_header
-            )
+            async with asyncio.timeout(SETUP_HTTP_TIMEOUT_SECONDS):
+                self._client, http_devices, creds_renewed = await get_or_test_creds(
+                    http_api_url=self._http_api_endpoint,
+                    creds=self._cached_creds,
+                    ua_header=self._ua_header
+                )
         except (BadLoginException, TokenExpiredException, UnauthorizedException) as err:
             raise ConfigEntryAuthFailed from err
         except HttpApiError as err:
             raise ConfigEntryNotReady(f"Error communicating with API: {err}") from err
-        except (aiohttp.ClientError, asyncio.TimeoutError) as err:
-            # Transient transport failure: retry setup rather than give up
-            raise ConfigEntryNotReady(f"Error communicating with API: {err}") from err
+        except RETRYABLE_TRANSPORT_ERRORS as err:
+            # Transient transport failure (DNS not up yet, WAN down, connection refused/reset,
+            # unscoped IPv6 address, timeout, or a non-200 reply such as the 502 the local add-on's
+            # nginx returns while Flask is still starting): retry setup rather than give up.
+            # HA logs ConfigEntryNotReady at INFO only, so this WARNING is what the user will see.
+            _LOGGER.warning(
+                "Could not reach the Meross HTTP API at %s (%s: %s). Home Assistant will retry the "
+                "setup automatically.",
+                self._http_api_endpoint, type(err).__name__, err,
+            )
+            raise ConfigEntryNotReady(
+                f"Cannot reach the Meross HTTP API at {self._http_api_endpoint}: "
+                f"{type(err).__name__}: {err}"
+            ) from err
 
         # If a new token was issued, store it into the current entry
         if creds_renewed:
@@ -405,6 +444,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry):
                         str(DEFAULT_USER_AGENT))
         ua_header = DEFAULT_USER_AGENT
 
+    meross_coordinator = None
     try:
         # Setup the coordinator
         meross_coordinator = MerossCoordinator(
@@ -473,12 +513,28 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry):
             log_exception(msg, logger=_LOGGER)
             raise ConfigEntryNotReady()
 
-    except (aiohttp.ClientError, asyncio.TimeoutError) as ex:
-        # Cloud unreachable at setup time (DNS not up yet at boot, WAN down):
-        # retry with backoff instead of failing the entry permanently
-        msg = "Could not reach the Meross cloud while setting up the integration."
-        log_exception(msg, logger=_LOGGER)
-        raise ConfigEntryNotReady(msg) from ex
+    except RETRYABLE_TRANSPORT_ERRORS as ex:
+        # Cloud/broker unreachable at setup time (DNS not up yet at boot, WAN down, local add-on
+        # still starting): retry with backoff instead of failing the entry permanently.
+        # Only reachable after get_or_test_creds() succeeded: MerossManager.async_device_discovery()
+        # makes a second devList call, Hub/getSubDevices calls and, for online devices, MQTT commands
+        # whose paho client.connect() is synchronous and raises OSError subclasses directly when the
+        # broker is not accepting connections yet.
+        # HA does not call async_unload_entry on ConfigEntryNotReady, so release the manager (paho
+        # client thread / broker connection) here or every retry leaks one.
+        if meross_coordinator is not None and meross_coordinator.manager is not None:
+            try:
+                meross_coordinator.manager.close()
+            except Exception:  # best effort, we are already failing setup
+                _LOGGER.debug("Manager cleanup after failed setup raised", exc_info=True)
+        _LOGGER.warning(
+            "Meross setup could not reach %s or the MQTT broker (%s: %s). Home Assistant will retry "
+            "the setup automatically.",
+            http_api_endpoint, type(ex).__name__, ex,
+        )
+        raise ConfigEntryNotReady(
+            f"Cannot reach Meross services ({http_api_endpoint} / MQTT): {type(ex).__name__}: {ex}"
+        ) from ex
 
 
 async def update_listener(hass, entry):

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+testpaths = tests
+asyncio_mode = auto
+asyncio_default_fixture_loop_scope = function
+pythonpath = .

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,0 +1,2 @@
+pytest-homeassistant-custom-component==0.13.364
+meross_iot==0.4.10.4

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+"""Shared fixtures: let HA's test harness load custom_components/meross_cloud."""
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def auto_enable_custom_integrations(enable_custom_integrations):
+    """enable_custom_integrations is provided by pytest-homeassistant-custom-component."""
+    yield

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,136 @@
+"""Setup-entry error handling for meross_cloud."""
+import errno
+import logging
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+import pytest
+from aiohttp import ClientConnectorError
+from aiohttp.client_reqrep import ConnectionKey
+from homeassistant.config_entries import SOURCE_REAUTH, ConfigEntryState
+from homeassistant.core import HomeAssistant
+from meross_iot.model.http.exception import AuthenticatedPostException, TokenExpiredException
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.meross_cloud.common import (
+    CONF_HTTP_ENDPOINT,
+    CONF_MQTT_SKIP_CERT_VALIDATION,
+    CONF_STORED_CREDS,
+    DEVICE_LIST_COORDINATOR,
+    DOMAIN,
+)
+
+ENDPOINT = "http://homeassistant.local:2003"
+LOGGER_NAME = "custom_components.meross_cloud"
+# Same class object as custom_components.meross_cloud.MerossHttpClient; patching here avoids
+# importing the integration module ahead of HA's loader.
+LIST_DEVICES = "meross_iot.http_api.MerossHttpClient.async_list_devices"
+DEVICE_DISCOVERY = "meross_iot.manager.MerossManager.async_device_discovery"
+MANAGER_CLOSE = "meross_iot.manager.MerossManager.close"
+FORWARD_SETUPS = "homeassistant.config_entries.ConfigEntries.async_forward_entry_setups"
+
+
+def _connector_error(host="homeassistant.local", port=2003, err=errno.EINVAL, msg="Invalid argument"):
+    """Build a ClientConnectorError the way aiohttp's connector does.
+
+    ConnectionKey is a NamedTuple whose fields differ across aiohttp releases, so fill it by
+    field name and leave unknown fields at None.
+    """
+    values = {
+        "host": host, "port": port, "is_ssl": False, "ssl": True, "proxy": None,
+        "proxy_auth": None, "proxy_headers_hash": None, "server_hostname": None,
+    }
+    key = ConnectionKey(*[values.get(field) for field in ConnectionKey._fields])
+    return ClientConnectorError(key, OSError(err, msg))
+
+
+@pytest.fixture
+def config_entry(hass: HomeAssistant) -> MockConfigEntry:
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title=ENDPOINT,
+        data={
+            CONF_HTTP_ENDPOINT: ENDPOINT,
+            CONF_MQTT_SKIP_CERT_VALIDATION: True,
+            CONF_STORED_CREDS: {
+                "token": "token", "key": "key", "user_id": "1", "user_email": "user@example.com",
+                "issued_on": datetime(2026, 1, 1, tzinfo=timezone.utc).isoformat(),
+                "domain": ENDPOINT, "mqtt_domain": "homeassistant.local:2001",
+            },
+        },
+    )
+    entry.add_to_hass(hass)
+    return entry
+
+
+def _retry_warnings(caplog):
+    return [
+        r for r in caplog.records
+        if r.name == LOGGER_NAME and r.levelno == logging.WARNING
+        and "Home Assistant will retry" in r.getMessage()
+    ]
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        _connector_error(),
+        AuthenticatedPostException("Failed request to API. Response code: 502"),
+        OSError(errno.ECONNREFUSED, "Connection refused"),
+        TimeoutError(),  # what asyncio.timeout(SETUP_HTTP_TIMEOUT_SECONDS) raises on expiry
+    ],
+    ids=["client_connector_error_einval", "nginx_502", "connection_refused", "timeout"],
+)
+async def test_transient_error_schedules_retry(hass: HomeAssistant, config_entry, error, caplog):
+    with caplog.at_level(logging.WARNING, logger=LOGGER_NAME), patch(LIST_DEVICES, side_effect=error):
+        assert not await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert config_entry.state is ConfigEntryState.SETUP_RETRY
+    assert "Error setting up entry" not in caplog.text  # HA's generic, non-retrying path
+    assert _retry_warnings(caplog), caplog.text
+
+
+async def test_token_expired_still_starts_reauth(hass: HomeAssistant, config_entry, caplog):
+    with patch(LIST_DEVICES, side_effect=TokenExpiredException()):
+        assert not await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()  # reauth flow is created as a task
+
+    assert config_entry.state is ConfigEntryState.SETUP_ERROR
+    assert "Error setting up entry" not in caplog.text
+    flows = hass.config_entries.flow.async_progress_by_handler(DOMAIN)
+    assert any(flow["context"]["source"] == SOURCE_REAUTH for flow in flows)
+
+
+async def test_discovery_transport_error_schedules_retry_and_closes_manager(
+    hass: HomeAssistant, config_entry, caplog
+):
+    """Failures after the device list (MQTT broker refused) must retry and release the manager."""
+    with caplog.at_level(logging.WARNING, logger=LOGGER_NAME), \
+            patch(LIST_DEVICES, return_value=[]), \
+            patch(DEVICE_DISCOVERY, side_effect=ConnectionRefusedError(errno.ECONNREFUSED, "Connection refused")), \
+            patch(MANAGER_CLOSE) as close:
+        assert not await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert config_entry.state is ConfigEntryState.SETUP_RETRY
+    assert "Error setting up entry" not in caplog.text
+    assert _retry_warnings(caplog), caplog.text
+    assert close.call_count == 1
+
+
+async def test_polling_transport_error_is_update_failed(hass: HomeAssistant, config_entry, caplog):
+    with patch(LIST_DEVICES, return_value=[]), patch(DEVICE_DISCOVERY, return_value=[]), \
+            patch(FORWARD_SETUPS):
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+    assert config_entry.state is ConfigEntryState.LOADED
+    coordinator = hass.data[DOMAIN][DEVICE_LIST_COORDINATOR]
+
+    caplog.clear()
+    with patch(LIST_DEVICES, side_effect=AuthenticatedPostException("Failed request to API. Response code: 502")):
+        await coordinator.async_refresh()
+
+    assert coordinator.last_update_success is False
+    assert "Unexpected error fetching" not in caplog.text
+    assert "Cannot reach the Meross HTTP API" in caplog.text


### PR DESCRIPTION
## Problem

`async_setup_entry` converts `meross_iot` exceptions into `ConfigEntryAuthFailed` or `ConfigEntryNotReady`, but transport errors raised by `aiohttp` are not handled. They propagate out of `async_setup_entry`, so HomeAssistant marks the entry `SETUP_ERROR`. That state is never retried, since only `ConfigEntryNotReady` triggers retry with backoff, so the integration stays down until the user reloads it by hand.

A momentary network hiccup at startup therefore takes the integration offline indefinitely. The usual trigger is HomeAssistant starting before the network is ready, so the first `devList` call fails on DNS:

```
ERROR (MainThread) [homeassistant.config_entries] Error setting up entry https://iot.meross.com for meross_cloud
  File "custom_components/meross_cloud/__init__.py", line 420, in async_setup_entry
    await meross_coordinator.initial_setup()
  File "custom_components/meross_cloud/__init__.py", line 144, in initial_setup
  File "custom_components/meross_cloud/__init__.py", line 342, in get_or_test_creds
  File "meross_iot/http_api.py", line 476, in async_list_devices
  File "meross_iot/http_api.py", line 341, in _async_authenticated_post
aiohttp.client_exceptions.ClientConnectorDNSError: Cannot connect to host iotx-eu.meross.com:443 ssl:default [Could not contact DNS servers]
```

One attempt, zero retries. On my install it sat in `SETUP_ERROR` for three days after a host reboot with every Meross device `unavailable`, while other cloud integrations that hit the same blip at the same moment recovered on their own.

#599 reports the same failure with an identical traceback (same lines 420, 144, 342) and `ClientConnectorError`, which is the WAN-drop variant of the same bug.

## Fix

Catch `aiohttp.ClientError` and `asyncio.TimeoutError` in `initial_setup` and `async_setup_entry`, and raise `ConfigEntryNotReady` so HomeAssistant retries with backoff.

`aiohttp.ClientError` is the common ancestor of both reported variants, `ClientConnectorDNSError` and `ClientConnectorError`, as well as `ClientOSError` and `ServerTimeoutError`.

Authentication handling is unchanged, so bad credentials still stop rather than retry forever.

## Testing

Verified against the aiohttp shipped with current HomeAssistant (3.14.3) that all four variants above are caught by `aiohttp.ClientError`.

Confirmed the recovery path on a live 1.3.12 install: the entry had been in `SETUP_ERROR` since a reboot three days earlier and came back immediately on a config entry reload, which is what `ConfigEntryNotReady` would have done automatically.

I did not fault inject a DNS failure against the patched code, as that would have meant deliberately breaking name resolution on a production setup. Happy to add that if you would like it verified that way.
